### PR TITLE
add chmod +x for testscripts to .travis.yml.2j

### DIFF
--- a/.travis.yml.j2
+++ b/.travis.yml.j2
@@ -29,7 +29,9 @@ install:
 
 # Run the tests
 script:
+  - chmod +x tests/test-ansible.sh
   - tests/test-ansible.sh
+  - chmod +x tests/test-spelling.sh
   - tests/test-spelling.sh
 
 notifications:


### PR DESCRIPTION
# Fix Permission issue 
- Test-Scripts now are executable
## Reference
- See: https://github.com/while-true-do/ansible-role-yum-cron/pull/4

Resolves: #4 