### PR TITLE
Fix: ansible galaxy role names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-python: 
+python:
   - "2.7"
   - "3.6"
 

--- a/dist/.travis.yml.j2
+++ b/dist/.travis.yml.j2
@@ -1,6 +1,6 @@
 ---
 language: python
-python: 
+python:
   - "2.7"
   - "3.6"
 

--- a/dist/.travis.yml.j2
+++ b/dist/.travis.yml.j2
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while-true-do.{{ role_name }}
+  - ln -s  $PWD ../while_true_do.{{ role_name }}
 
 # Run the tests
 script:

--- a/dist/README.md.j2
+++ b/dist/README.md.j2
@@ -3,7 +3,7 @@
 # Ansible Role: {{ role_name }}
 | A short description **what** the role does goes here.
 
-<!-- 
+<!--
 -  Explain a bit more, if needed.
 -  You can use bullets or write a small text
 -->
@@ -48,9 +48,9 @@ If nothing is needed, please write "None."
 
 ## Role Variables
 
-<!-- 
+<!--
 The variable files should explain itself and pasted/linked here.
-Explanation should be done **in** the files, if needed. 
+Explanation should be done **in** the files, if needed.
 -->
 
 ```yaml
@@ -68,7 +68,7 @@ bar: foo
 Simple Example:
 
 ```yaml
-- hosts: servers 
+- hosts: servers
   roles:
     - { role: while_true_do.{{ role_name }} }
 ```
@@ -76,7 +76,7 @@ Simple Example:
 Advanced Example:
 
 ```yaml
-- hosts: servers 
+- hosts: servers
   roles:
     - { role: while_true_do.{{ role_name }}, foo: bar, bar: foo }
 ```
@@ -95,7 +95,7 @@ bash ./tests/test-ansible.sh
 ## Contribute / Bugs
 
 Thank you so much for considering to contribute. Every contribution helps us.
-We are really happy, when somebody is joining the hard work. Please have a look 
+We are really happy, when somebody is joining the hard work. Please have a look
 at the links first.
 
 -   [Code of Conduct](./docs/CODE_OF_CONDUCT.md)

--- a/dist/README.md.j2
+++ b/dist/README.md.j2
@@ -14,16 +14,16 @@
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while-true-do/{{ role_name }})
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/{{ role_name }})
 
 ```
-ansible-galaxy install while-true-do.{{ role_name }}
+ansible-galaxy install while_true_do.{{ role_name }}
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-{{ role_name }})
 
 ```
-git clone https://github.com/while-true-do/ansible-role-{{ role_name }}.git while-true-do.{{ role_name }}
+git clone https://github.com/while-true-do/ansible-role-{{ role_name }}.git while_true_do.{{ role_name }}
 ```
 
 ## Requirements
@@ -70,7 +70,7 @@ Simple Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while-true-do.{{ role_name }} }
+    - { role: while_true_do.{{ role_name }} }
 ```
 
 Advanced Example:
@@ -78,7 +78,7 @@ Advanced Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while-true-do.{{ role_name }}, foo: bar, bar: foo }
+    - { role: while_true_do.{{ role_name }}, foo: bar, bar: foo }
 ```
 
 ## Testing

--- a/dist/docs/COMMIT_TEMPLATE.md
+++ b/dist/docs/COMMIT_TEMPLATE.md
@@ -32,7 +32,7 @@ Further paragraphs come after blank lines, if needed.
  - Bullet points are okay, too.
  - A hyphen or asterisk is used for the bullet, preceded by a single space and can
    be wrapped around.
-   
+
  - Resolves: #12
  - See also: #33, #44
 ```

--- a/dist/docs/CONTRIBUTING.md
+++ b/dist/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ In this document you can find some guidance, how you can take care of bugs, subm
 -   [Submit Changes and Pull Requests](#Submit-Changes-and-Pull-Requests)
 -   [Documentation](#Documentation)
 -   [Testing](#Testing)
-  
+
 ## Resources
 
 -   Documents: <https://github.com/while-true-do/community/>

--- a/dist/meta/main.yml.j2
+++ b/dist/meta/main.yml.j2
@@ -2,6 +2,7 @@
 dependencies: []
 
 galaxy_info:
+  role_name: {{ role_name }}
   author: while-true-do.org
   description: # Fill in the same description as in the README.md and for the repository
   company: while-true-do.org

--- a/dist/requirements.yml
+++ b/dist/requirements.yml
@@ -1,5 +1,5 @@
 # from galaxy
-# - src: while-true-do.yum
+# - src: while_true_do.yum
 
 # from GitHub
 # - src: https://github.com/while-true-do/ansible-role-yum

--- a/dist/tests/test.yml.j2
+++ b/dist/tests/test.yml.j2
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while-true-do.{{ role_name }}
+    - while_true_do.{{ role_name }}

--- a/dist/update-meta-files.sh
+++ b/dist/update-meta-files.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Description:
-#   update-skeleton.sh is a very minimal script to update the skeleton with 
-#   some additional content from while-true-do.org. It will not remove files, 
+#   update-skeleton.sh is a very minimal script to update the skeleton with
+#   some additional content from while-true-do.org. It will not remove files,
 #   you created. Replacement must be acknowledged.
 
 function usage {
@@ -90,7 +90,7 @@ function update_all {
 }
 
 while getopts 'admst' opts; do
-  
+
   case "${opts}" in
     a) update_all ;;
     d) update_docs ;;


### PR DESCRIPTION
# Fix: ansible galaxy role names

Ansible Galaxy decided to change "-" to "_" and there
is no way currently to roll this back.
So change the role names and galaxy links to "while_true_do"

Please have a look at: https://github.com/ansible/galaxy/issues/779

## Reference

 - Resolves: #27

## People
<!--
@mentions of somebody who was involved or should be involved.
@mentions of the person or team responsible for reviewing proposed changes.
-->
