### PR TITLE
Fix: wrong galaxy role_name in templates

### DIFF
--- a/dist/.travis.yml.j2
+++ b/dist/.travis.yml.j2
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while_true_do.{{ role_name }}
+  - ln -s  $PWD ../while_true_do.{{ role_name | replace("-", "_")}}
 
 # Run the tests
 script:

--- a/dist/README.md.j2
+++ b/dist/README.md.j2
@@ -14,10 +14,10 @@
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/{{ role_name }})
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/{{ role_name | replace("-", "_") }})
 
 ```
-ansible-galaxy install while_true_do.{{ role_name }}
+ansible-galaxy install while_true_do.{{ role_name | replace("-", "_") }}
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-{{ role_name }})
@@ -70,7 +70,7 @@ Simple Example:
 ```yaml
 - hosts: servers
   roles:
-    - { role: while_true_do.{{ role_name }} }
+    - { role: while_true_do.{{ role_name | replace("-", "_") }} }
 ```
 
 Advanced Example:
@@ -78,7 +78,7 @@ Advanced Example:
 ```yaml
 - hosts: servers
   roles:
-    - { role: while_true_do.{{ role_name }}, foo: bar, bar: foo }
+    - { role: while_true_do.{{ role_name | replace("-", "_")}}, foo: bar, bar: foo }
 ```
 
 ## Testing

--- a/dist/defaults/main.yml.j2
+++ b/dist/defaults/main.yml.j2
@@ -1,5 +1,5 @@
 ---
-# defaults/main.yml for {{ role_name }}
+# defaults/main.yml for {{ role_name | replace("-", "_")}}
 #
 # All Variables must be prefixed with "wtd_":
 #

--- a/dist/handlers/main.yml.j2
+++ b/dist/handlers/main.yml.j2
@@ -1,2 +1,2 @@
 ---
-# handlers/main.yml for {{ role_name }}
+# handlers/main.yml for {{ role_name | replace("-", "_")}}

--- a/dist/meta/main.yml.j2
+++ b/dist/meta/main.yml.j2
@@ -2,7 +2,7 @@
 dependencies: []
 
 galaxy_info:
-  role_name: {{ role_name }}
+  role_name: {{ role_name | replace("-", "_")}}
   author: while-true-do.org
   description: # Fill in the same description as in the README.md and for the repository
   company: while-true-do.org

--- a/dist/tasks/main.yml.j2
+++ b/dist/tasks/main.yml.j2
@@ -1,2 +1,2 @@
 ---
-# tasks/main.yml for {{ role_name }}
+# tasks/main.yml for {{ role_name | replace("-", "_")}}

--- a/dist/tests/test.yml.j2
+++ b/dist/tests/test.yml.j2
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while_true_do.{{ role_name }}
+    - while_true_do.{{ role_name | replace("-", "_")}}


### PR DESCRIPTION
<!--
Please have a look at the contribution guidelines and commit template first.

https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md
https://github.com/while-true-do/community/blob/master/docs/COMMIT_TEMPLATE.md
-->

# Fix: wrong galaxy role_name in templates

Replace ```-``` in all Ansible Galaxy related role_name entries to ```_```.
<!--
Further paragraphs come after blank lines, if needed.

 - Bullet points are okay, too
 - A hyphen or asterisk is used for the bullet, preceded by a single space.
-->

## Reference

<!--
Please be aware, that every pull-request/merge-request for released (stable) repositories needs an issue.
-->

 - Resolves: #35 
 - See also: 

## (Optional) People

<!--
@mentions of somebody who was involved or should be involved.
@mentions of the person or team responsible for reviewing proposed changes.
-->
