### PR TITLE
Fix: wrong galaxy role_name in README.md

### DIFF
--- a/dist/README.md.j2
+++ b/dist/README.md.j2
@@ -23,7 +23,7 @@ ansible-galaxy install while_true_do.{{ role_name | replace("-", "_") }}
 Install from [Github](https://github.com/while-true-do/ansible-role-{{ role_name }})
 
 ```
-git clone https://github.com/while-true-do/ansible-role-{{ role_name }}.git while_true_do.{{ role_name }}
+git clone https://github.com/while-true-do/ansible-role-{{ role_name }}.git while_true_do.{{ role_name | replace("-", "_") }}
 ```
 
 ## Requirements


### PR DESCRIPTION
<!--
Please have a look at the contribution guidelines and commit template first.

https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md
https://github.com/while-true-do/community/blob/master/docs/COMMIT_TEMPLATE.md
-->

# Fix: wrong galaxy role_name in README.md

<!--
Further paragraphs come after blank lines, if needed.

 - Bullet points are okay, too
 - A hyphen or asterisk is used for the bullet, preceded by a single space.
-->

## Reference

<!--
Please be aware, that every pull-request/merge-request for released (stable) repositories needs an issue.
-->

 - Resolves: #39 
 - See also:

## (Optional) People

<!--
@mentions of somebody who was involved or should be involved.
@mentions of the person or team responsible for reviewing proposed changes.
-->
