### PR TITLE
Fix: Spellcheck now ignores inline code blocks

### DIFF
--- a/dist/tests/test-spelling.sh
+++ b/dist/tests/test-spelling.sh
@@ -17,8 +17,8 @@ printf "***          %s          ***\\n" "Spell Checking"
 printf "%s\\n" "$WTD_HR_LINE"
 printf "%b" "$WTD_COLOR_OFF"
 
-BADWORDS=$(sed "/^\`\`\`/,/^\`\`\`/d" "$WTD_SCRIPT_DIR/../README.md" | aspell --lang=en --encoding=utf-8 \
-  --personal="$WTD_SCRIPT_DIR/.aspell.en.pws" list)
+BADWORDS=$(sed -e "/^\`\`\`/,/^\`\`\`/d" -e "s/\`.*\`//g" "$WTD_SCRIPT_DIR/../README.md" | \
+  aspell --lang=en --encoding=utf-8 --personal="$WTD_SCRIPT_DIR/.aspell.en.pws" list)
 
 BADWORDS_COUNT=$(echo "$BADWORDS" | wc -w)
 

--- a/tests/test-spelling.sh
+++ b/tests/test-spelling.sh
@@ -17,8 +17,8 @@ printf "***          %s          ***\\n" "Spell Checking"
 printf "%s\\n" "$WTD_HR_LINE"
 printf "%b" "$WTD_COLOR_OFF"
 
-BADWORDS=$(sed "/^\`\`\`/,/^\`\`\`/d" "$WTD_SCRIPT_DIR/../README.md" | aspell --lang=en --encoding=utf-8 \
-  --personal="$WTD_SCRIPT_DIR/.aspell.en.pws" list)
+BADWORDS=$(sed -e "/^\`\`\`/,/^\`\`\`/d" -e "s/\`.*\`//g" "$WTD_SCRIPT_DIR/../README.md" | \
+  aspell --lang=en --encoding=utf-8 --personal="$WTD_SCRIPT_DIR/.aspell.en.pws" list)
 
 BADWORDS_COUNT=$(echo "$BADWORDS" | wc -w)
 


### PR DESCRIPTION


<!--
Please have a look at the contribution guidelines and commit template first.

https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md
https://github.com/while-true-do/community/blob/master/docs/COMMIT_TEMPLATE.md
-->

# Fix: Spellcheck now ignores inline code blocks

<!--
Further paragraphs come after blank lines, if needed.

 - Bullet points are okay, too
 - A hyphen or asterisk is used for the bullet, preceded by a single space.
-->
Spellcheck now ignoes inline code blocks in README.md using single backticks

## Reference

<!--
Please be aware, that every pull-request/merge-request for released (stable) repositories needs an issue.
-->

 - Resolves: #43